### PR TITLE
Fix license for audio/utils.cpp and audio/utils.h

### DIFF
--- a/audio/utils.cpp
+++ b/audio/utils.cpp
@@ -1,19 +1,3 @@
-/*  cuse-maru - CUSE implementation of Open Sound System using libmaru.
- *  Copyright (C) 2012 - Hans-Kristian Arntzen
- *  Copyright (C) 2012 - Agnes Heyer
- *
- *  cuse-maru is free software: you can redistribute it and/or modify it under the terms
- *  of the GNU General Public License as published by the Free Software Found-
- *  ation, either version 3 of the License, or (at your option) any later version.
- *
- *  cuse-maru is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
- *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
- *  PURPOSE.  See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with cuse-maru.
- *  If not, see <http://www.gnu.org/licenses/>.
- */
-
 #include "utils.h"
 
 #if __SSE2__

--- a/audio/utils.h
+++ b/audio/utils.h
@@ -1,19 +1,3 @@
-/*  cuse-maru - CUSE implementation of Open Sound System using libmaru.
- *  Copyright (C) 2012 - Hans-Kristian Arntzen
- *  Copyright (C) 2012 - Agnes Heyer
- *
- *  cuse-maru is free software: you can redistribute it and/or modify it under the terms
- *  of the GNU General Public License as published by the Free Software Found-
- *  ation, either version 3 of the License, or (at your option) any later version.
- *
- *  cuse-maru is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
- *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
- *  PURPOSE.  See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with cuse-maru.
- *  If not, see <http://www.gnu.org/licenses/>.
- */
-
 #ifndef AUDIO_UTILS_H
 #define AUDIO_UTILS_H
 


### PR DESCRIPTION
Following discussion with copyright holder Themaister on IRC, the
GPL3+ license is in error and it should be the same non-commercial
license as the rest of the code.
