### PR TITLE
workaround for gcc7 compile error

### DIFF
--- a/utils.hpp
+++ b/utils.hpp
@@ -18,6 +18,11 @@
 
 #include <pugixml/pugixml.hpp>
 
+#define GCC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
+#if GCC_VERSION >= 70000
+#include <functional>
+#endif
+
 namespace Blit
 {
    namespace Utils


### PR DESCRIPTION
fix for  'error: 'function' in namespace 'std' does not name a template type' when compiling using gcc above version 7.0